### PR TITLE
Project config

### DIFF
--- a/src/webpack/mergeConfigs.js
+++ b/src/webpack/mergeConfigs.js
@@ -1,4 +1,31 @@
+const { resolve } = require('path');
 const merge = require('webpack-merge');
 
-module.exports = webpackConfigs =>
-  merge(webpackConfigs);
+const PROJECT_CONFIG_DIR = 'jetpack';
+
+const resolveProjectConfig = (root, filename) => {
+  try {
+    const projectConfigPath = resolve(root, PROJECT_CONFIG_DIR, filename);
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    return require(projectConfigPath);
+  } catch (err) {
+    return null;
+  }
+};
+
+module.exports = (webpackConfigs, settings, env) => {
+  const webpackConfig = merge(webpackConfigs);
+  const projectConfig = resolveProjectConfig(settings.paths.root, 'webpack.config.js');
+
+  // Full-control mode
+  if (typeof projectConfig === 'function') {
+    return projectConfig(webpackConfig, settings, env);
+  }
+
+  // Config mode
+  if (typeof projectConfig === 'object') {
+    merge.smart(webpackConfig, projectConfig);
+  }
+
+  return webpackConfig;
+};

--- a/src/webpack/mergeConfigs.js
+++ b/src/webpack/mergeConfigs.js
@@ -1,0 +1,4 @@
+const merge = require('webpack-merge');
+
+module.exports = webpackConfigs =>
+  merge(webpackConfigs);

--- a/src/webpack/webpack.config.dev.js
+++ b/src/webpack/webpack.config.dev.js
@@ -1,8 +1,8 @@
 const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+const mergeConfigs = require('./mergeConfigs');
 const {
   createEslintConfig,
   createJavascriptConfig,
@@ -63,8 +63,9 @@ const devConfig = {
   }
 };
 
-module.exports = webpackMerge(
+module.exports = mergeConfigs([
   devConfig,
+
   createResolveConfig(),
   createEslintConfig({
     include: paths.src
@@ -78,8 +79,11 @@ module.exports = webpackMerge(
     lint: true
   }, env),
   createStylusConfig({
-    include: paths.src
+    include: paths.src,
+    root: paths.root
   }),
   createLessConfig(),
-  createFileConfig({ context: paths.src }, env)
-);
+  createFileConfig({
+    context: paths.src
+  }, env)
+]);

--- a/src/webpack/webpack.config.dev.js
+++ b/src/webpack/webpack.config.dev.js
@@ -12,12 +12,14 @@ const {
   createLessConfig,
   createFileConfig
 } = require('./config');
-const { paths } = require('./defaults');
+const settings = require('./defaults');
 
 const env = {
   ENV: 'development',
   NODE_ENV: 'development'
 };
+
+const { paths } = settings;
 
 const devConfig = {
   context: paths.src,
@@ -86,4 +88,4 @@ module.exports = mergeConfigs([
   createFileConfig({
     context: paths.src
   }, env)
-]);
+], settings, env);

--- a/src/webpack/webpack.config.prd.js
+++ b/src/webpack/webpack.config.prd.js
@@ -1,9 +1,9 @@
 const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
+const mergeConfigs = require('./mergeConfigs');
 const RenderWebpackPlugin = require('./renderWebpackPlugin');
 const {
   context,
@@ -27,7 +27,7 @@ const env = {
   NODE_ENV: 'production'
 };
 
-const clientConfig = routes => webpackMerge(
+const clientConfig = routes => mergeConfigs([
   {
     bail: true,
     context,
@@ -89,9 +89,9 @@ const clientConfig = routes => webpackMerge(
     globDirectory: paths.output.path,
     swDest: paths.output.swDest,
   })
-);
+]);
 
-const renderConfig = webpackMerge(
+const renderConfig = mergeConfigs([
   {
     bail: true,
     context,
@@ -130,6 +130,6 @@ const renderConfig = webpackMerge(
     context: paths.src,
     emitFile: false
   }, env)
-);
+]);
 
 module.exports = { renderConfig, clientConfig };

--- a/src/webpack/webpack.config.prd.js
+++ b/src/webpack/webpack.config.prd.js
@@ -5,11 +5,7 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 const mergeConfigs = require('./mergeConfigs');
 const RenderWebpackPlugin = require('./renderWebpackPlugin');
-const {
-  context,
-  paths,
-  minimize
-} = require('./defaults');
+const settings = require('./defaults')
 const {
   createJavascriptConfig,
   createResolveConfig,
@@ -26,6 +22,12 @@ const env = {
   ENV: 'production',
   NODE_ENV: 'production'
 };
+
+const {
+  context,
+  paths,
+  minimize
+} = settings;
 
 const clientConfig = routes => mergeConfigs([
   {
@@ -89,7 +91,7 @@ const clientConfig = routes => mergeConfigs([
     globDirectory: paths.output.path,
     swDest: paths.output.swDest,
   })
-]);
+], settings, env);
 
 const renderConfig = mergeConfigs([
   {
@@ -130,6 +132,6 @@ const renderConfig = mergeConfigs([
     context: paths.src,
     emitFile: false
   }, env)
-]);
+], settings, env);
 
 module.exports = { renderConfig, clientConfig };

--- a/src/webpack/webpack.config.stg.js
+++ b/src/webpack/webpack.config.stg.js
@@ -17,12 +17,14 @@ const {
   createCommonChunks,
   createBuildInfo
 } = require('./config');
-const { paths } = require('./defaults');
+const settings = require('./defaults');
 
 const env = {
   ENV: 'staging',
   NODE_ENV: 'production'
 };
+
+const { paths } = settings;
 
 const stageConfig = {
   bail: true,
@@ -91,4 +93,4 @@ module.exports = mergeConfigs([
     globDirectory: paths.output.path,
     swDest: paths.output.swDest,
   })
-]);
+], settings, env);

--- a/src/webpack/webpack.config.stg.js
+++ b/src/webpack/webpack.config.stg.js
@@ -1,11 +1,11 @@
 const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
+const mergeConfigs = require('./mergeConfigs');
 const {
   createJavascriptConfig,
   createResolveConfig,
@@ -64,8 +64,9 @@ const stageConfig = {
   ]
 };
 
-module.exports = webpackMerge(
+module.exports = mergeConfigs([
   stageConfig,
+
   createResolveConfig(),
   createJavascriptConfig({
     include: paths.src
@@ -79,7 +80,9 @@ module.exports = webpackMerge(
     include: paths.src
   }),
   createLessConfig(),
-  createFileConfig({ context: paths.src }, env),
+  createFileConfig({
+    context: paths.src
+  }, env),
   createCommonChunks(),
   createBuildInfo({
     output: paths.output.buildInfo
@@ -88,4 +91,4 @@ module.exports = webpackMerge(
     globDirectory: paths.output.path,
     swDest: paths.output.swDest,
   })
-);
+]);


### PR DESCRIPTION
Allow updating the webpack config at the project level.

The first option was to use a config file at the project level (eg: `jetpack.config.js`) and add customization support case by case. 

Since we are still at the point of having a lot of changes, we need more liberty to customize, so I implemented the storybook solution with a specific `webpack.config.js` that can export:
- `object` -> merge
- `function` -> call it with the existing config + settings 