### PR TITLE
Fix worker error reporting

### DIFF
--- a/src/prerender/worker.js
+++ b/src/prerender/worker.js
@@ -79,16 +79,15 @@ module.exports = (options, done) => {
     primeCacheTask,
     nextTask => async.parallelLimit(restTasks, concurrentConnections, nextTask)
   ], (err, [primeCacheRoute, otherRoutes]) => {
-    if (err) console.log(err)
     log('Done');
 
-    done(err, {
+    done(err && err.stack, {
       id,
       duration: perf.end(workerNamespace),
       fetchCount: global.workerFetchCount,
       routes: [
         primeCacheRoute,
-        ...otherRoutes
+        ...(otherRoutes || [])
       ]
     });
   });


### PR DESCRIPTION
Prevent worker JSON.stringify error on application error

---

The worker will stringify the objects to be passed between processes and the error object contains a circular reference. This was throwing an error in the child process and the entire build was hanging.

